### PR TITLE
Committee module

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -20,6 +20,7 @@ body .main {
 @import "components/appMainModule/aboutPageModule/aboutPage";
 @import "components/appMainModule/faqPageModule/faqPage";
 @import "components/common/cityModule/city";
+@import "components/common/committeeModule/styles";
 
 //Angular UI Bootstrap Required Styling:
 .nav, .pagination, .carousel, .panel-title a { cursor: pointer; }

--- a/app/components/common/appMainNav/appMainNav.html
+++ b/app/components/common/appMainNav/appMainNav.html
@@ -19,6 +19,7 @@
             <li ui-sref-active="active" ng-click="navCollapsed = true"><a ui-sref="home">Home</a></li>
             <li ui-sref-active="active"><a ui-sref="appMain.examplePage1" ng-click="navCollapsed = !navCollapsed">Example Page 1</a></li>
             <li ui-sref-active="active"><a ui-sref="appMain.city">City</a></li>
+            <li ui-sref-active="active"><a ui-sref="appMain.committee({committee_id: 1})">Committee</a></li>
             <!--<li ng-repeat="item in mainNavMenu" ui-sref-active="active"><a ng-click="navCollapsed = !navCollapsed" ui-sref="{{item.sref}}">{{item.title}}</a></li>-->
           </ul>
 

--- a/app/components/common/appMainNav/appMainNav.html
+++ b/app/components/common/appMainNav/appMainNav.html
@@ -19,7 +19,7 @@
             <li ui-sref-active="active" ng-click="navCollapsed = true"><a ui-sref="home">Home</a></li>
             <li ui-sref-active="active"><a ui-sref="appMain.examplePage1" ng-click="navCollapsed = !navCollapsed">Example Page 1</a></li>
             <li ui-sref-active="active"><a ui-sref="appMain.city">City</a></li>
-            <li ui-sref-active="active"><a ui-sref="appMain.committee({committee_id: 1})">Committee</a></li>
+            <li ui-sref-active="active"><a ui-sref="appMain.committee.main({committee_id: 1})">Committee</a></li>
             <!--<li ng-repeat="item in mainNavMenu" ui-sref-active="active"><a ng-click="navCollapsed = !navCollapsed" ui-sref="{{item.sref}}">{{item.title}}</a></li>-->
           </ul>
 

--- a/app/components/common/cityModule/city.html
+++ b/app/components/common/cityModule/city.html
@@ -15,13 +15,7 @@
   </div>
   <div class="section">
     <p>Where is the money coming from?</p>
-    <dl>
-      <dt>Within {{ city.location.name }}</dt>
-      <dd>{{ city.contribution_by_area.inside_location }}</dd>
-      <dt>In-state</dt>
-      <dd>{{ city.contribution_by_area.inside_state }}</dd>
-      <dt>Out-of-state</dt>
-      <dd>{{ city.contribution_by_area.outside_state }}</dd>
-    </dl>
+    <div contribution-area-breakdown="city.contribution_by_area" location="city.location"></div>
   </div>
 </div>
+

--- a/app/components/common/cityModule/city.html
+++ b/app/components/common/cityModule/city.html
@@ -11,20 +11,7 @@
     <div>
       <span>{{ city.contribution_total }}</span>
     </div>
-    <dl>
-      <dt>Individual</dt>
-      <dd>{{ city.contribution_by_type.individual }}</dd>
-      <dt>Political Party</dt>
-      <dd>{{ city.contribution_by_type.political_party }}</dd>
-      <dt>Not Itemized</dt>
-      <dd><i>Small (unitemized) contributions are those under $100</i></dd>
-      <dd>{{ city.contribution_by_type.unitemized }}</dd>
-      <dt>Recipient Commitee</dt>
-      <dd><i>This category includes Political Action Committees (PACs)&#x2026;</i></dd>
-      <dd>{{ city.contribution_by_type.recipient_committee }}</dd>
-      <dt>Self-Funded</dt>
-      <dd>{{ city.contribution_by_type.self_funded }}</dd>
-    </dl>
+    <div contribution-type-breakdown="city.contribution_by_type"></div>
   </div>
   <div class="section">
     <p>Where is the money coming from?</p>

--- a/app/components/common/cityModule/index.js
+++ b/app/components/common/cityModule/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
+require('../contributionTypeBreakdown');
+
 var cityModule = angular.module('cityModule', [
+    'contributionTypeBreakdown',
     'appMainModule'
   ])
   .controller('cityController', require('./cityController'));

--- a/app/components/common/cityModule/index.js
+++ b/app/components/common/cityModule/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
+require('../contributionAreaBreakdown');
 require('../contributionTypeBreakdown');
 
 var cityModule = angular.module('cityModule', [
+    'contributionAreaBreakdown',
     'contributionTypeBreakdown',
     'appMainModule'
   ])

--- a/app/components/common/committeeModule/controllers/committee.js
+++ b/app/components/common/committeeModule/controllers/committee.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function committeeController($scope, committee) {
+  $scope.committee = committee;
+}
+
+module.exports = committeeController;

--- a/app/components/common/committeeModule/controllers/contributors.js
+++ b/app/components/common/committeeModule/controllers/contributors.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function contributorsController($scope, contributors) {
+  $scope.contributors = contributors;
+}
+
+module.exports = contributorsController;
+

--- a/app/components/common/committeeModule/index.js
+++ b/app/components/common/committeeModule/index.js
@@ -1,0 +1,19 @@
+/**
+ * committeeModule/index.js
+ *
+ * The committee module contains several pages containing information on a
+ * single campaign committee.
+ **/
+
+'use strict';
+
+require('../contributionTypeBreakdown');
+
+var committeeModule = angular.module('committeeModule', [
+    'contributionTypeBreakdown',
+    'appMainModule'
+  ])
+  .controller('committeeController', require('./controllers/committee'))
+  .config(require('./state'));
+
+module.exports = committeeModule;

--- a/app/components/common/committeeModule/index.js
+++ b/app/components/common/committeeModule/index.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+require('../contributionAreaBreakdown');
 require('../contributionTypeBreakdown');
 
 var committeeModule = angular.module('committeeModule', [
@@ -14,6 +15,7 @@ var committeeModule = angular.module('committeeModule', [
     'appMainModule'
   ])
   .controller('committeeController', require('./controllers/committee'))
+  .controller('contributorsController', require('./controllers/contributors'))
   .config(require('./state'));
 
 module.exports = committeeModule;

--- a/app/components/common/committeeModule/state.js
+++ b/app/components/common/committeeModule/state.js
@@ -1,0 +1,45 @@
+/**
+ * committeeModule/state.js
+ *
+ * The ui-router state configuration for the committee module. Contains several
+ * pages containing information on a single campaign committee.
+ **/
+
+module.exports = function($stateProvider) {
+  $stateProvider.state({
+    name: 'appMain.committee',
+    url: '^/committee/:committee_id',
+    controller: 'committeeController',
+    template: require('./templates/committee.html'),
+    ncyBreadcrumb: {
+      label: '{{ committee.name }}',
+      parent: 'appMain.city'
+    },
+    resolve: {
+      committee: function($stateParams, $q) {
+        return $q.resolve({
+          committee_id: 1234,
+          name: 'Americans for Liberty',
+          contribution_by_type: {
+            unitemized: 2916394,
+            self_funded: 512554,
+            political_party: 6426112,
+            individual: 11134547,
+            recipient_committee: 986229
+          },
+          contribution_by_area: {
+            inside_location: 0.56,
+            inside_state: 0.38,
+            outside_state: 0.06
+          }
+        });
+      }
+    },
+    data: {
+      moduleClasses: 'page',
+      pageClasses: 'committee',
+      pageTitle: 'Committee',
+      pageDescription: 'A campaign committee.'
+    }
+  });
+};

--- a/app/components/common/committeeModule/state.js
+++ b/app/components/common/committeeModule/state.js
@@ -8,13 +8,10 @@
 module.exports = function($stateProvider) {
   $stateProvider.state({
     name: 'appMain.committee',
+    abstract: true,
     url: '^/committee/:committee_id',
+    template: '<ui-view></ui-view>',
     controller: 'committeeController',
-    template: require('./templates/committee.html'),
-    ncyBreadcrumb: {
-      label: '{{ committee.name }}',
-      parent: 'appMain.city'
-    },
     resolve: {
       committee: function($stateParams, $q) {
         return $q.resolve({
@@ -40,6 +37,54 @@ module.exports = function($stateProvider) {
       pageClasses: 'committee',
       pageTitle: 'Committee',
       pageDescription: 'A campaign committee.'
+    }
+  });
+
+  $stateProvider.state({
+    name: 'appMain.committee.main',
+    url: '',
+    template: require('./templates/committee.html'),
+    ncyBreadcrumb: {
+      label: '{{ committee.name }}',
+      parent: 'appMain.city'
+    }
+  });
+
+  $stateProvider.state({
+    name: 'appMain.committee.contributors',
+    url: '/contributors',
+    controller: 'contributorsController',
+    template: require('./templates/contributors.html'),
+    ncyBreadcrumb: {
+      label: 'Contributors',
+      parent: 'appMain.committee.main'
+    },
+    resolve: {
+      contributors: function($stateParams, $q) {
+        return $q.resolve([
+          {
+            name: 'Samantha Brooks',
+            amount: 700,
+            date: new Date('2015-04-12')
+          },
+          {
+            name: 'Lisa Sheppards',
+            amount: 700,
+            date: new Date('2015-01-13')
+          },
+          {
+            name: 'Raoul Esponsito',
+            amount: 700,
+            date: new Date('2015-04-04')
+          }
+        ]);
+      }
+    },
+    data: {
+      moduleClasses: 'page',
+      pageClasses: 'contributors',
+      pageTitle: 'Committee contributors',
+      pageDescription: 'Contributors to a campaign committee.'
     }
   });
 };

--- a/app/components/common/committeeModule/styles.less
+++ b/app/components/common/committeeModule/styles.less
@@ -1,0 +1,3 @@
+.search-container {
+  margin: 1rem 0;
+}

--- a/app/components/common/committeeModule/styles.less
+++ b/app/components/common/committeeModule/styles.less
@@ -1,3 +1,14 @@
 .search-container {
   margin: 1rem 0;
 }
+
+.more-details-cta {
+  & > a {
+    &:after {
+      position: relative;
+      top: 0.1em;
+      content: ' ›';
+      font-size: 2em;
+    }
+  }
+}

--- a/app/components/common/committeeModule/templates/committee.html
+++ b/app/components/common/committeeModule/templates/committee.html
@@ -2,6 +2,7 @@
 <div class="divided-section">
   <h4>Contributions</h4>
   <div contribution-type-breakdown="committee.contribution_by_type"></div>
+  <span class="more-details-cta"><a ui-sref="appMain.committee.contributors({commitee_id: committee.committee_id})">more details</a></span>
 </div>
 <div class="divided-section">
   <h4>Where is the money coming from?</h4>

--- a/app/components/common/committeeModule/templates/committee.html
+++ b/app/components/common/committeeModule/templates/committee.html
@@ -1,0 +1,9 @@
+<h3>{{ committee.name }}</h3>
+<div class="divided-section">
+  <h4>Contributions</h4>
+  <div contribution-type-breakdown="committee.contribution_by_type"></div>
+</div>
+<div class="divided-section">
+  <h4>Where is the money coming from?</h4>
+  <div contribution-area-breakdown="committee.contribution_by_area"></div>
+</div>

--- a/app/components/common/committeeModule/templates/contributors.html
+++ b/app/components/common/committeeModule/templates/contributors.html
@@ -1,0 +1,62 @@
+<div class="search-container input-group">
+  <span class="input-group-addon"><i class="fa fa-search"></i></span>
+  <input class="search-input form-control" type="text" ng-model="query" placeholder="Search contributors">
+</div>
+<div class="subtitle"><span>Top 5 contributors by category</span></div>
+<div class="divided-section">
+  <h4>Individual</h4>
+  <table>
+    <thead>
+      <tr>
+        <th>Contributor</th>
+        <th>Amount</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="contributor in contributors">
+        <td>{{ contributor.name }}</td>
+        <td class="money">{{ contributor.amount | currency:$:0 }}</td>
+        <td>{{ contributor.date | date:"yyyy-MM-dd" }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="divided-section">
+  <h4>Other (includes businesses)</h4>
+  <table>
+    <thead>
+      <tr>
+        <th>Contributor</th>
+        <th>Amount</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="contributor in contributors">
+        <td>{{ contributor.name }}</td>
+        <td class="money">{{ contributor.amount | currency:$:0 }}</td>
+        <td>{{ contributor.date | date:"yyyy-MM-dd" }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class="divided-section">
+  <h4>Committee</h4>
+  <table>
+    <thead>
+      <tr>
+        <th>Contributor</th>
+        <th>Amount</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="contributor in contributors">
+        <td>{{ contributor.name }}</td>
+        <td class="money">{{ contributor.amount | currency:$:0 }}</td>
+        <td>{{ contributor.date | date:"yyyy-MM-dd" }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/components/common/contributionAreaBreakdown/contributions.html
+++ b/app/components/common/contributionAreaBreakdown/contributions.html
@@ -1,0 +1,8 @@
+<dl>
+  <dt>Within {{ location.name || "metro" }}</dt>
+  <dd>{{ contributionByArea.inside_location }}</dd>
+  <dt>In-state</dt>
+  <dd>{{ contributionByArea.inside_state }}</dd>
+  <dt>Out-of-state</dt>
+  <dd>{{ contributionByArea.outside_state }}</dd>
+</dl>

--- a/app/components/common/contributionAreaBreakdown/controller.js
+++ b/app/components/common/contributionAreaBreakdown/controller.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function contributionAreaBreakdownController() {
+  // Do some d3 stuff!
+}
+
+module.exports = contributionAreaBreakdownController;
+

--- a/app/components/common/contributionAreaBreakdown/index.js
+++ b/app/components/common/contributionAreaBreakdown/index.js
@@ -1,0 +1,23 @@
+/**
+ * contributionAreaBreakdown/index.js
+ *
+ * UI element breaking down campaign contributions by area.
+ **/
+
+'use strict';
+
+var contributionAreaBreakdown = angular.module('contributionAreaBreakdown', [])
+  .directive('contributionAreaBreakdown', function contributionAreaBreakdown() {
+    return {
+      controller: require('./controller'),
+      controllerAs: 'ctrl',
+      restrict: 'EA',
+      scope: {
+        contributionByArea: '=contributionAreaBreakdown',
+        location: '=location'
+      },
+      template: require('./contributions.html')
+    };
+  });
+
+module.exports = contributionAreaBreakdown;

--- a/app/components/common/contributionTypeBreakdown/contributions.html
+++ b/app/components/common/contributionTypeBreakdown/contributions.html
@@ -1,0 +1,14 @@
+<dl>
+  <dt>Individual</dt>
+  <dd class="money">{{ contributionByType.individual | currency:$:0 }}</dd>
+  <dt>Political Party</dt>
+  <dd class="money">{{ contributionByType.political_party | currency:$:0 }}</dd>
+  <dt>Not Itemized</dt>
+  <dd><i>Small (unitemized) contributions are those under $100</i></dd>
+  <dd class="money">{{ contributionByType.unitemized | currency:$:0 }}</dd>
+  <dt>Recipient Commitee</dt>
+  <dd><i>This category includes Political Action Committees (PACs)&#x2026;</i></dd>
+  <dd class="money">{{ contributionByType.recipient_committee | currency:$:0 }}</dd>
+  <dt>Self-Funded</dt>
+  <dd class="money">{{ contributionByType.self_funded | currency:$:0 }}</dd>
+</dl>

--- a/app/components/common/contributionTypeBreakdown/controller.js
+++ b/app/components/common/contributionTypeBreakdown/controller.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function contributionTypeBreakdownController() {
+  // Do some d3 stuff!
+}
+
+module.exports = contributionTypeBreakdownController;

--- a/app/components/common/contributionTypeBreakdown/index.js
+++ b/app/components/common/contributionTypeBreakdown/index.js
@@ -1,0 +1,22 @@
+/**
+ * contributionTypeBreakdown/index.js
+ *
+ * UI element breaking down campaign contributions by type.
+ **/
+
+'use strict';
+
+var contributions = angular.module('contributionTypeBreakdown', [])
+  .directive('contributionTypeBreakdown', function contributionTypeBreakdown() {
+    return {
+      controller: require('./controller'),
+      controllerAs: 'ctrl',
+      restrict: 'EA',
+      scope: {
+        contributionByType: '=contributionTypeBreakdown'
+      },
+      template: require('./contributions.html')
+    };
+  });
+
+module.exports = contributions;

--- a/app/components/components.js
+++ b/app/components/components.js
@@ -3,9 +3,11 @@
 require('./homePageModule/homePage');
 require('./appMainModule/appMain');
 require('./common/cityModule');
+require('./common/committeeModule');
 
 module.exports = angular.module('components', [
   'homePageModule',
   'appMainModule',
-  'cityModule'
+  'cityModule',
+  'committeeModule'
 ]);


### PR DESCRIPTION
This provides the committee pages, describing a single ballot committee, fixes #46 #47 

Pulled out the contribution breakdown tables into single components via a directive. Rather than putting all the state configuration in `appRoutes.js`, this module handles it's own routing via `state.js`. I think this pattern works well, and provides more modularity (each module registers it's own state).

I left out the hackery to get the city breadcrumbs working for now. The other breadcrumbs on these pages work.

