### PR TITLE
Enable tests / fix jshint/jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -12,7 +12,7 @@
     },
     "disallowSpacesInsideParentheses": true,
     "disallowTrailingWhitespace": "ignoreEmptyLines",
-    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
     "requireCapitalizedConstructors": true,
     "requireCurlyBraces": true,
     "requireSpaceAfterKeywords": [

--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
   "browser": true,
   "esnext": true,
   "bitwise": true,
-  "camelcase": true,
+  "camelcase": false,
   "curly": true,
   "eqeqeq": true,
   "immed": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+
+script:
+  - npm test

--- a/app/components/appMainModule/aboutPageModule/AboutPageController.js
+++ b/app/components/appMainModule/aboutPageModule/AboutPageController.js
@@ -2,7 +2,7 @@
   'use strict';
   // Controller naming conventions should start with an uppercase letter
   function AboutPageController($scope) {
-
+        // jshint unused: vars
   }
 
   // $inject is necessary for minification. See http://bit.ly/1lNICde for explanation.

--- a/app/components/appMainModule/appMain.js
+++ b/app/components/appMainModule/appMain.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* exported examplePage1Module, aboutPageModule */
+/* exported faqPageModule, measurePageModule */
 var examplePage1Module = require('./examplePage1Module/examplePage1');
 var aboutPageModule = require('./aboutPageModule/aboutPage');
 var faqPageModule = require('./faqPageModule/faqPage');

--- a/app/components/appMainModule/measurePageModule/state.js
+++ b/app/components/appMainModule/measurePageModule/state.js
@@ -5,6 +5,8 @@
  * pages containing information on a single ballot measure.
  **/
 
+'use strict';
+
 module.exports = function($stateProvider) {
   $stateProvider
     .state({
@@ -63,7 +65,7 @@ module.exports = function($stateProvider) {
         parent: 'appMain.measure.index'
       },
       resolve: {
-        supporters:function($stateParams, $q) {
+        supporters: function($stateParams, $q) {
           return $q.resolve([
             {name: 'Citizens for a Better Oakland', contributions: 185859},
             {name: 'Oaklanders for Ethical Government', contributions: 152330},

--- a/app/components/common/cityModule/cityElectionsController.js
+++ b/app/components/common/cityModule/cityElectionsController.js
@@ -1,11 +1,6 @@
 'use strict';
 
 function cityElectionsController($scope, ballot) {
-  $scope.ballot = ballot;
-
-  $scope.isOffice = isOffice;
-  $scope.isReferendum = isReferendum;
-
   function isOffice(contest) {
     return contest.contest_type === 'office';
   }
@@ -13,6 +8,10 @@ function cityElectionsController($scope, ballot) {
   function isReferendum(contest) {
     return contest.contest_type === 'referendum';
   }
+
+  $scope.ballot = ballot;
+  $scope.isOffice = isOffice;
+  $scope.isReferendum = isReferendum;
 }
 
 module.exports = cityElectionsController;

--- a/app/components/common/committeeModule/state.js
+++ b/app/components/common/committeeModule/state.js
@@ -5,6 +5,8 @@
  * pages containing information on a single campaign committee.
  **/
 
+'use strict';
+
 module.exports = function($stateProvider) {
   $stateProvider.state({
     name: 'appMain.committee',

--- a/app/components/homePageModule/HomePageController.js
+++ b/app/components/homePageModule/HomePageController.js
@@ -5,9 +5,11 @@
     $scope.searchBarEnabled = false;
     $scope.testVar = 'We are up and running using a required module!';
     $scope.searchResults = [];
+
     // This is pretty jank, we should debounce this or do the search when the
     // user stops typing.
-    $scope.$watch('search', function(newValue, old) {
+    // jshint unused: vars
+    $scope.$watch('search', function(newValue, oldValue) {
       if (typeof newValue === 'undefined') {
         return;
       }

--- a/app/components/services/disclosure/index.spec.js
+++ b/app/components/services/disclosure/index.spec.js
@@ -31,11 +31,11 @@ describe('disclosureApi', function() {
     expect(disclosureApi).to.have.property('search');
   });
 
-  it('lists 10 contributions', function() {
-    // This hits a live API, so changes outside of this project could failt his test :(
+  it('lists some contributions', function() {
+    // This hits a live API, so changes outside of this project could fail this test :(
     return disclosureApi.contributions.list()
       .then(function(contributions) {
-        expect(contributions).to.have.length(9);
+        expect(contributions[0]).to.have.property('amount');
       });
   });
 });

--- a/app/components/services/disclosure/index.spec.js
+++ b/app/components/services/disclosure/index.spec.js
@@ -12,7 +12,7 @@ describe('disclosureApi', function() {
   }));
 
   it('exists', function() {
-    expect(disclosureApi).to.be.ok;
+    expect(disclosureApi).to.be.ok;  // jshint ignore:line
   });
 
   it('has contributions', function() {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Disclosure-Frontend-Alpha",
   "version": "1.0.0",
   "description": "Base AngularJS application with gulp and browserify",
+  "license" : "MIT",
   "main": "app.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Running npm tests locally wasn't working well, due to the large # of jshint/jscs failures and a brittle test for an API endpoint.

I updated the code, some of the jshint/jscs settings, and the test, then added `npm test` to the Travis config file, so that hopefully future PRs will maintain working tests and get auto-style-checked.
